### PR TITLE
Use filepaths for tslint-files instead of requiring

### DIFF
--- a/lib/plugins/typescript/tasks/lint.js
+++ b/lib/plugins/typescript/tasks/lint.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const tslint = require('gulp-tslint');
+const tslint = require('@5minds/gulp-tslint');
 
 
 const tslintDefaultConfiguration = path.resolve(__filename, '../../setup/tslint.json');
@@ -19,7 +19,7 @@ function generate(gulp, config, gulptraum) {
     if (config.paths.tslintConfig) {
       tslintConfiguration = path.resolve(config.paths.root, config.paths.tslintConfig);
     }
-
+    
     return gulp.src(sourceFolderPath)
       .pipe(tslint({
         formatter: 'prose',
@@ -27,7 +27,7 @@ function generate(gulp, config, gulptraum) {
         configuration: tslintConfiguration,
       }))
       .pipe(tslint.report({
-        emitError: false,
+        emitError: !config.suppressErrors,
       }));
   });
 


### PR DESCRIPTION
Tslint as used in gulptraum could not handle custom tslints, which extended other tslints.
That means the following would not work in a tslint.json specified with the gulptraum setting `tslintConfig`:

```
my_tslint.json:
{
    "extends": "tslint-config-5minds"
}
```

The problem was that tslint expects a path to the json instead of an object containing all the rules(which was the case before due to require).
Tslint does consider an object with rules(which is why this bug was never noticed) but will not resolve an object containing the key `extends`.